### PR TITLE
Added Lokalise branch filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ workflows:
           requires:
             - unit-test
       - automerge-lokalise:
-          #filters:
-          #  branches:
-          #    only:
-          #      - /^lokalise-[\d|\-|_]+$/
+          filters:
+            branches:
+              only:
+                - /^lokalise-[\d|\-|_]+$/
           requires:
             - build
 jobs:


### PR DESCRIPTION
### Description

This PR adds a filter so the `automerge-lokalise` only triggers for branches the schema expected for automated PRs from Lokalise.